### PR TITLE
examples: remove duplicate comments

### DIFF
--- a/examples/MinimalModemNBIOTExample/MinimalModemNBIOTExample.ino
+++ b/examples/MinimalModemNBIOTExample/MinimalModemNBIOTExample.ino
@@ -60,8 +60,6 @@ const char server[]   = "vsh.pp.ua";
 const char resource[] = "/TinyGSM/logo.txt";
 
 //!! Set the APN manually. Some operators need to set APN first when registering the network.
-//!! Set the APN manually. Some operators need to set APN first when registering the network.
-//!! Set the APN manually. Some operators need to set APN first when registering the network.
 // Using 7080G with Hologram.io , https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/issues/19
 // const char *apn = "hologram";
 
@@ -169,7 +167,7 @@ void setup()
     Serial.printf("getNetworkMode:%u getPreferredMode:%u\n", mode, pre);
 
 
-    //Set the APN manually. Some operators need to set APN first when registering the network.
+    //!! Set the APN manually. Some operators need to set APN first when registering the network.
     modem.sendAT("+CGDCONT=1,\"IP\",\"", apn, "\"");
     if (modem.waitResponse() != 1) {
         Serial.println("Set operators apn Failed!");

--- a/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
+++ b/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
@@ -48,8 +48,6 @@ enum {
 
 
 //!! Set the APN manually. Some operators need to set APN first when registering the network.
-//!! Set the APN manually. Some operators need to set APN first when registering the network.
-//!! Set the APN manually. Some operators need to set APN first when registering the network.
 // Using 7080G with Hologram.io , https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/issues/19
 // const char *apn = "hologram";
 
@@ -195,7 +193,7 @@ void setup()
     Serial.printf("getNetworkMode:%u getPreferredMode:%u\n", mode, pre);
 
 
-    //Set the APN manually. Some operators need to set APN first when registering the network.
+    //!! Set the APN manually. Some operators need to set APN first when registering the network.
     modem.sendAT("+CGDCONT=1,\"IP\",\"", apn, "\"");
     if (modem.waitResponse() != 1) {
         Serial.println("Set operators apn Failed!");

--- a/examples/ModemMqttsExample/ModemMqttsExample.ino
+++ b/examples/ModemMqttsExample/ModemMqttsExample.ino
@@ -80,8 +80,6 @@ enum {
 
 
 //!! Set the APN manually. Some operators need to set APN first when registering the network.
-//!! Set the APN manually. Some operators need to set APN first when registering the network.
-//!! Set the APN manually. Some operators need to set APN first when registering the network.
 // Using 7080G with Hologram.io , https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/issues/19
 // const char *apn = "hologram";
 
@@ -268,7 +266,7 @@ void setup()
 
     Serial.printf("getNetworkMode:%u getPreferredMode:%u\n", mode, pre);
 
-    //Set the APN manually. Some operators need to set APN first when registering the network.
+    //!! Set the APN manually. Some operators need to set APN first when registering the network.
     modem.sendAT("+CGDCONT=1,\"IP\",\"", apn, "\"");
     if (modem.waitResponse() != 1) {
         Serial.println("Set operators apn Failed!");


### PR DESCRIPTION
## Description

There are three comments like the below.

```
//!! Set the APN manually. Some operators need to set APN first when registering the network.
//!! Set the APN manually. Some operators need to set APN first when registering the network.
//!! Set the APN manually. Some operators need to set APN first when registering the network.
```

It's no need to write the multi same comments.
Therefore, I removed them.

In addition, unify the comments missing the double exclamation mark.