### PR TITLE
examples: fix register_info typo

### DIFF
--- a/examples/AllFunction/modem.cpp
+++ b/examples/AllFunction/modem.cpp
@@ -19,10 +19,10 @@
 #if defined(USING_MODEM)
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/BIGIOT_Gnss_Upload/BIGIOT_Gnss_Upload.ino
+++ b/examples/BIGIOT_Gnss_Upload/BIGIOT_Gnss_Upload.ino
@@ -45,10 +45,10 @@ bool  level     = false;
 
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/MinimalModemNBIOTExample/MinimalModemNBIOTExample.ino
+++ b/examples/MinimalModemNBIOTExample/MinimalModemNBIOTExample.ino
@@ -32,10 +32,10 @@ TinyGsm        modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/MinimalModemPowerSaveMode/MinimalModemPowerSaveMode.ino
+++ b/examples/MinimalModemPowerSaveMode/MinimalModemPowerSaveMode.ino
@@ -32,10 +32,10 @@ TinyGsm        modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/MinimalModemSleepMode/MinimalModemSleepMode.ino
+++ b/examples/MinimalModemSleepMode/MinimalModemSleepMode.ino
@@ -32,10 +32,10 @@ TinyGsm        modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/ModemMqttPublishExample/ModemMqttPublishExample.ino
+++ b/examples/ModemMqttPublishExample/ModemMqttPublishExample.ino
@@ -32,10 +32,10 @@ TinyGsm        modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
+++ b/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
@@ -32,10 +32,10 @@ TinyGsm        modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/ModemMqttsAuthExample/ModemMqttsAuthExample.ino
+++ b/examples/ModemMqttsAuthExample/ModemMqttsAuthExample.ino
@@ -36,10 +36,10 @@ TinyGsm        modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/ModemMqttsExample/ModemMqttsExample.ino
+++ b/examples/ModemMqttsExample/ModemMqttsExample.ino
@@ -34,14 +34,14 @@ TinyGsm modem(SerialAT);
 
 const char *register_info[] = {
     "Not registered, MT is not currently searching an operator to register "
-    "to.The GPRS service is disabled, the UE is allowed to attach for GPRS if "
+    "to. The GPRS service is disabled, the UE is allowed to attach for GPRS if "
     "requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an "
     "operator to register to. The GPRS service is enabled, but an allowable "
     "PLMN is currently not available. The UE will start a GPRS attach as soon "
     "as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed "
+    "Registration denied, the GPRS service is disabled, the UE is not allowed "
     "to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",

--- a/examples/SIM7080G-ATT-NB-IOT-AWS-MQTT/SIM7080G-ATT-NB-IOT-AWS-MQTT.ino
+++ b/examples/SIM7080G-ATT-NB-IOT-AWS-MQTT/SIM7080G-ATT-NB-IOT-AWS-MQTT.ino
@@ -55,10 +55,10 @@ TinyGsm modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/SIM7080G-ATT-NB-IOT-HTTP-HTTPS/SIM7080G-ATT-NB-IOT-HTTP-HTTPS.ino
+++ b/examples/SIM7080G-ATT-NB-IOT-HTTP-HTTPS/SIM7080G-ATT-NB-IOT-HTTP-HTTPS.ino
@@ -36,10 +36,10 @@ TinyGsm modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };

--- a/examples/SIM7080G-ATT-NB-IOT-SSL-Mosquitto/SIM7080G-ATT-NB-IOT-SSL-Mosquitto.ino
+++ b/examples/SIM7080G-ATT-NB-IOT-SSL-Mosquitto/SIM7080G-ATT-NB-IOT-SSL-Mosquitto.ino
@@ -46,10 +46,10 @@ TinyGsm modem(SerialAT);
 #endif
 
 const char *register_info[] = {
-    "Not registered, MT is not currently searching an operator to register to.The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
+    "Not registered, MT is not currently searching an operator to register to. The GPRS service is disabled, the UE is allowed to attach for GPRS if requested by the user.",
     "Registered, home network.",
     "Not registered, but MT is currently trying to attach or searching an operator to register to. The GPRS service is enabled, but an allowable PLMN is currently not available. The UE will start a GPRS attach as soon as an allowable PLMN is available.",
-    "Registration denied, The GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
+    "Registration denied, the GPRS service is disabled, the UE is not allowed to attach for GPRS if it is requested by the user.",
     "Unknown.",
     "Registered, roaming.",
 };


### PR DESCRIPTION
## Summary

Fix some typos.

| Before | After |
|--------|--------|
| ... register to.The GPRS ... | ... register to. The GPRS ... |
| Registration denied, **T**he GPRS... | Registration denied, **t**he GPRS... |
