### PR TITLE
docs: fix invalid bigiot link

### DIFF
--- a/examples/BIGIOT_Gnss_Upload/README.MD
+++ b/examples/BIGIOT_Gnss_Upload/README.MD
@@ -1,5 +1,5 @@
 
-[Platform link](www.bigiot.net)
+[Platform link](https://www.bigiot.net)
 [Relevant communication protocol of Shell IOT users](https://www.bigiot.net/help/33.html)
 
 ## Current consumption


### PR DESCRIPTION
# Summary

Update the [platform link](https://www.bigiot.net/) in [BIGIOT_Gnss_Upload README.MD](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/tree/master/examples/BIGIOT_Gnss_Upload).

## Before

![before](https://github.com/user-attachments/assets/5dfe7b7b-8c65-4854-9e8d-aa2e70e1c0ae)

## After

![after](https://github.com/user-attachments/assets/6593e7a1-a8ef-4602-8acb-ada837a1dc30)
