### PR TITLE
chore: remove duplicate `utilities.h` inclusion

### DIFF
--- a/examples/BIGIOT_Gnss_Upload/BIGIOT_Gnss_Upload.ino
+++ b/examples/BIGIOT_Gnss_Upload/BIGIOT_Gnss_Upload.ino
@@ -14,7 +14,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 #include "bigiot.h"
 

--- a/examples/MinimalDeepSleepExample/MinimalDeepSleepExample.ino
+++ b/examples/MinimalDeepSleepExample/MinimalDeepSleepExample.ino
@@ -20,7 +20,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 // Set to wake up every 5 minutes to send positioning coordinates to the platform
 #define uS_TO_S_FACTOR 1000000ULL                       /* Conversion factor for micro seconds to seconds */

--- a/examples/MinimalModemGPSExample/MinimalModemGPSExample.ino
+++ b/examples/MinimalModemGPSExample/MinimalModemGPSExample.ino
@@ -20,7 +20,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/MinimalModemNBIOTExample/MinimalModemNBIOTExample.ino
+++ b/examples/MinimalModemNBIOTExample/MinimalModemNBIOTExample.ino
@@ -20,7 +20,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/MinimalModemPowerSaveMode/MinimalModemPowerSaveMode.ino
+++ b/examples/MinimalModemPowerSaveMode/MinimalModemPowerSaveMode.ino
@@ -20,7 +20,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/MinimalModemSleepMode/MinimalModemSleepMode.ino
+++ b/examples/MinimalModemSleepMode/MinimalModemSleepMode.ino
@@ -20,7 +20,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/MinimalModemUpgrade/MinimalModemUpgrade.ino
+++ b/examples/MinimalModemUpgrade/MinimalModemUpgrade.ino
@@ -25,7 +25,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/ModemMqttPublishExample/ModemMqttPublishExample.ino
+++ b/examples/ModemMqttPublishExample/ModemMqttPublishExample.ino
@@ -20,7 +20,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
+++ b/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
@@ -20,7 +20,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/ModemMqttsAuthExample/ModemMqttsAuthExample.ino
+++ b/examples/ModemMqttsAuthExample/ModemMqttsAuthExample.ino
@@ -24,7 +24,6 @@ XPowersPMU  PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS

--- a/examples/ModemMqttsExample/ModemMqttsExample.ino
+++ b/examples/ModemMqttsExample/ModemMqttsExample.ino
@@ -21,7 +21,6 @@ XPowersPMU PMU;
 
 #define TINY_GSM_MODEM_SIM7080
 #include <TinyGsmClient.h>
-#include "utilities.h"
 
 
 #ifdef DUMP_AT_COMMANDS


### PR DESCRIPTION
## Summary

I notice there are two `#include "utilities.h"` declaration  in some examples.
This PR delete the one of them.