### PR TITLE
docs: fix typo `Donwload` to `Download`

### DIFF
--- a/docs/sim7080_update_firmware.md
+++ b/docs/sim7080_update_firmware.md
@@ -26,7 +26,7 @@
     ![](../image/update_simxxxx_7.png)
 
 
-5. Donwload [upgrade_tool](https://github.com/Xinyuan-LilyGO/LilyGo-T-PCIE/tree/master/update_simxxxx_firmware/upgrade_tool/SIM7080_SIM7500_SIM7600_SIM7900_SIM8200%20QDL%20V1.58%20Only%20for%20Update)
+5. Download [upgrade_tool](https://github.com/Xinyuan-LilyGO/LilyGo-T-PCIE/tree/master/update_simxxxx_firmware/upgrade_tool/SIM7080_SIM7500_SIM7600_SIM7900_SIM8200%20QDL%20V1.58%20Only%20for%20Update)
 6. Open `sim7080_sim7500_sim7600_sim7900_sim8200 qdl v1.58 only for update.exe` 
 7.  Open the upgrade tool and follow the diagram below 
 


### PR DESCRIPTION
## Summary

Update `Donwload` to `Download` in [sim7080_update_firmware.md](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/blob/b7595e7331ea8afbd9eb68f381d82af1523e9dff/docs/sim7080_update_firmware.md?plain=1#L29).