### PR TITLE
docs: fix hidden MinimalModemUpgrade message

### DIFF
--- a/docs/sim7080_update_firmware.md
+++ b/docs/sim7080_update_firmware.md
@@ -1,7 +1,7 @@
 
 ## Quick Step
 
-1. Update the built-in firmware of ESP32S3 to<MinimalModemUpgrade>to ensure that the program is only responsible for enabling SIM7080G
+1. Update the built-in firmware of ESP32S3 using [MinimalModemUpgrade](../examples/MinimalModemUpgrade/MinimalModemUpgrade.ino) to ensure that the program is only responsible for enabling SIM7080G
 2. Connect the two USB ports of the board, USB-C and Micro-USB, and operate according to the following image
 
 3. Open [SIM7080 Driver](https://github.com/Xinyuan-LilyGO/LilyGo-T-PCIE/tree/master/update_simxxxx_firmware/USB_driver/SIMCOM_Windows_USB_Drivers_V1.0.2.exe)


### PR DESCRIPTION
# Summary

There is a typo `toto` in [sim7080_update_firmware.md](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/blob/master/docs/sim7080_update_firmware.md) due to wrong markup.

https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/blob/9e7ae8be1e67028e3bf9f74d793b3182036efd80/docs/sim7080_update_firmware.md?plain=1#L4

This PR update it.

## Before

![before](https://github.com/user-attachments/assets/1d9f6d6d-b05d-413e-8303-7aa189de2328)

## After

![after](https://github.com/user-attachments/assets/3706c0a6-453b-4e00-a239-6dd25487fa79)
