### PR TITLE
chore: add missing example and sort alphabetically to `platformio.ini`

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,26 +10,28 @@
 
 [platformio]
 ; src_dir = examples/AllFunction
-src_dir = examples/MinimalCameraExample
-; src_dir = examples/MinimalModemGPSExample
-; src_dir = examples/MinimalModemNBIOTExample
-; src_dir = examples/MinimalModemPowerSaveMode
-; src_dir = examples/MinimalModemSleepMode
-; src_dir = examples/MinimalModemUpgrade
-; src_dir = examples/MinimalPowersExample
-; src_dir = examples/MinimalLowBattPowerOffExample
-; src_dir = examples/MinimalPowersCurrentExample
-; src_dir = examples/MinimalSDCardExample
-; src_dir = examples/ModemMqttPublishExample
-; src_dir = examples/ModemMqttSubscribeExample
-; src_dir = examples/ModemMqttsExample
+; src_dir = examples/ATDebug
 ; src_dir = examples/BIGIOT_Gnss_Upload
 ; src_dir = examples/BLE5_extended_scan
 ; src_dir = examples/BLE5_multi_advertising
 ; src_dir = examples/BLE5_periodic_advertising
 ; src_dir = examples/BLE5_periodic_sync
-; src_dir = examples/ATDebug
+src_dir = examples/MinimalCameraExample
+; src_dir = examples/MinimalDeepSleepExample
+; src_dir = examples/MinimalLowBattPowerOffExample
+; src_dir = examples/MinimalModemGPSExample
+; src_dir = examples/MinimalModemNBIOTExample
+; src_dir = examples/MinimalModemPowerSaveMode
+; src_dir = examples/MinimalModemSleepMode
+; src_dir = examples/MinimalModemUpgrade
+; src_dir = examples/MinimalPowersCurrentExample
+; src_dir = examples/MinimalPowersExample
+; src_dir = examples/MinimalSDCardExample
 ; src_dir = examples/ModemFileUploadExample
+; src_dir = examples/ModemMqttPublishExample
+; src_dir = examples/ModemMqttsAuthExample
+; src_dir = examples/ModemMqttsExample
+; src_dir = examples/ModemMqttSubscribeExample
 
 ; By @bootcampiot https://github.com/bootcampiot
 ; src_dir = examples/SIM7080G-ATT-NB-IOT-AWS-MQTT


### PR DESCRIPTION
## Summary

Add the missing [MinimalDeepSleepExample](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/tree/master/examples/MinimalDeepSleepExample) and [ModemMqttsAuthExample](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/tree/master/examples/ModemMqttsAuthExample) examples to [platformio.ini](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/blob/master/platformio.ini).

Furthermore, sort them alphabetically.