### PR TITLE
docs: add flat top 18650 battery to README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,11 +7,9 @@
 - SIM7080G supports **NB-IoT** and **Cat-M** in global frequency bands, but does **not support 2G/3G/4G**. Please confirm that the SIM card used supports **NB-IoT** or **Cat-M** before use.
 - The SIM card must be inserted first before starting the SIM7080. If the SIM card is inserted after the SIM7080 is turned on, the modem will not be able to detect the SIM card.
 
-
 ## 1️⃣ Examples preview
 
 ```
-
 examples 
 ├─AllFunction                       # Full function test example
 ├─ATDebug                           # AT Commands Example
@@ -39,9 +37,7 @@ examples
 ├─SIM7080G-ATT-NB-IOT-AWS-MQTT      # MQTTS AWS By @bootcampiot
 ├─SIM7080G-ATT-NB-IOT-HTTP-HTTPS    # HTTP/HTTPS  By @bootcampiot
 └─SIM7080G-ATT-NB-IOT-SSL-Mosquitto # MQTTS Mosquitto By @bootcampiot
-
 ```
-
 
 ## 2️⃣ Quick Start
 
@@ -135,30 +131,27 @@ Please enter the upload mode manually.
 | ----- | --- | --- | --- | --- | --- |
 | GPIO  | 41  | 4   | 5   | 3   | 42  |
 
-
 | PMU  | SDA | SCL | IRQ |
 | ---- | --- | --- | --- |
 | GPIO | 15  | 7   | 6   |
-
 
 | SDCard | CMD | CLK | DATA |
 | ------ | --- | --- | ---- |
 | GPIO   | 39  | 38  | 40   |
 
-## Power domain
+## 6️⃣ Power domain
 
 | Modem          | Camera            | ESP32S3 | SDCard | Level conversion |
 | -------------- | ----------------- | ------- | ------ | ---------------- |
 | DC3/BLDO2(GPS) | ALDO1/ALDO2/ALDO4 | DC1     | ALDO3  | BLDO1            |
 
-
-## Voltage range
+## 7️⃣ Voltage range
 
 | Battery Voltage requirements | Minimum | Maximum | Charging Current              |
 | ---------------------------- | ------- | ------- | ----------------------------- |
 | SIM7080G                     | 3.5V    | 4.2V    | Custom adjustment, maximum 1A |
 
-* It is recommended to use 18650 batteries with a capacity of more than 2500mA
+* It is recommended to use flat top 18650 batteries with a capacity of more than 2500mA
 
 | Solar Voltage requirements | Minimum | Maximum | Charging Current |
 | -------------------------- | ------- | ------- | ---------------- |
@@ -166,7 +159,7 @@ Please enter the upload mode manually.
 
 * It is recommended to use a solar panel with an output voltage of 6V or 5V and a recommended power of about 5~10W. Solar energy can only charge the battery and cannot power the board without the battery.
 
-## ON-BOARD LED
+## 8️⃣ ON-BOARD LED
 
 | FUNCTION            | COLOR                                                |
 | ------------------- | ---------------------------------------------------- |

--- a/README_CN.MD
+++ b/README_CN.MD
@@ -1,15 +1,10 @@
-
-
-
 <h1 align = "center">✨ LilyGO T-SIM7080G ✨</h1>
 
 ## **[English](README.MD) | 中文**
 
-
 ## 1️⃣ 示例预览
 
 ```
-
 examples 
 ├─AllFunction                       # 全功能测试示例
 ├─ATDebug                           # AT命令示例
@@ -37,9 +32,7 @@ examples
 ├─SIM7080G-ATT-NB-IOT-AWS-MQTT      # MQTTS AWS By @bootcampiot
 ├─SIM7080G-ATT-NB-IOT-HTTP-HTTPS    # HTTP/HTTPS  By @bootcampiot
 └─SIM7080G-ATT-NB-IOT-SSL-Mosquitto # MQTTS Mosquitto By @bootcampiot
-
 ```
-
 
 ## 2️⃣ 快速开始
 
@@ -55,9 +48,7 @@ examples
 8. 点击（→）上传固件
 9. 点击 (插头符号) 监视串行输出
 
-
 ### ArduinoIDE
-
 
 1. 安装 [ArduinoIDE](https://www.arduino.cc/en/software)
 2. 将 `LilyGo-T-SIM7080G/lib` 目录内的所有文件夹拷贝到`<C:\Users\UserName\Documents\Arduino\libraries>`,如果没有`libraries`目录,请新建,请注意,不是拷贝`lib`目录,而是拷贝lib目录里面的文件夹
@@ -75,13 +66,13 @@ examples
    - Upload Mode -> UART0/Hardware CDC
    - Upload Speed -> 921600
 4. 插入USB到PC,点击上传<如果无法顺利上传,请保持按压BOOT按键,然后单击RST,然后再点击上传,上传完成时需要点击RST退出下载模式>
+
 ### Use reference
 
 |   Product   |                             Youtube  link                             |                  explanation                    | Status | 
 | :---------: | :-------------------------------------------------------------------: |:-----------------------------------------------:| :----: |
 | T -7080G | [Youtube link](https://www.youtube.com/watch?v=lGctqLDGHz4) |    How to update the firmware of SIM7080G series products     |   ✅    |
 | LilyGo device | [Youtube link](https://www.youtube.com/watch?v=f3BybP3L7ls) |    How to enter boot mode to download the firmware     |   ✅    |
-
 
 ## 3️⃣ 提示:
 
@@ -100,7 +91,6 @@ examples
 12. ⚠ **请在更改外设电压之前明白需要面临的风险,否则请不要尝试更改摄像头和其他板载设备的电压,可能会面临永久性的损坏**
 13. ⚠ **请不要关闭BLDO1电源，否则ESP32S3与SIM7080G无法正常通讯.**
 14. 更新调制解调器内置固件请查看[操作说明](./docs/sim7080_update_firmware.md),一般情况下不建议升级固件.
-
 
 ## 4️⃣ 在哪购买:
 
@@ -122,22 +112,19 @@ examples
    Wire.begin(sda,scl)
    ```
 
-
 | Modem | PWR | RXD | TXD | RI  | DTR |
 | ----- | --- | --- | --- | --- | --- |
 | GPIO  | 41  | 4   | 5   | 3   | 42  |
-
 
 | PMU  | SDA | SCL | IRQ |
 | ---- | --- | --- | --- |
 | GPIO | 15  | 7   | 6   |
 
-
 | SDCard | CMD | CLK | DATA |
 | ------ | --- | --- | ---- |
 | GPIO   | 39  | 38  | 40   |
 
-## 电源域
+## 6️⃣ 电源域
 
 | Modem          | Camera            | ESP32S3 | SDCard | Level conversion |
 | -------------- | ----------------- | ------- | ------ | ---------------- |


### PR DESCRIPTION
## Description

I bought **button top** 18650 battery.
However, I can't use it because T-SIM7080G supports **flat top** one.
So I added the **flat top** word to [README.MD](https://github.com/Marukome0743/LilyGo-T-SIM7080G/blob/master/README.MD) to prevent a mistake.

```diff
- It is recommended to use 18650 batteries with a capacity of more than 2500mA
+ It is recommended to use flat top 18650 batteries with a capacity of more than 2500mA
```

This PR also added the numbers to h2 tag like the below.

```diff
- ## Power domain
+ ## 6️⃣ Power domain
```

In addition, remove some unnecessary newline.