### PR TITLE
docs: add esp sleep example to Chinese README

### DIFF
--- a/README_CN.MD
+++ b/README_CN.MD
@@ -20,6 +20,7 @@ examples
 ├─MinimalModemNBIOTExample          # SIM7080G NBIOT 示例
 ├─MinimalModemPowerSaveMode         # SIM7080G 电源保持示例
 ├─MinimalModemSleepMode             # SIM7080G 睡眠示例
+├─MinimalModemAndEspSleep           # SIM7080G & ESP32 睡眠示例
 ├─MinimalModemUpgrade               # SIM7080G 升级内置固件
 ├─MinimalPowersCurrentExample       # PMU 充电电流调试
 ├─MinimalPowersExample              # PMU使用示例


### PR DESCRIPTION
## Summary

Follow up commit [`568e78b`](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/commit/568e78b18e63d340e5e47eefc6f3144f54f489d5).
Add [MinimalModemAndEspSleep](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/tree/master/examples/MinimalModemAndEspSleep) example to [README_CN.MD](https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/blob/master/README_CN.MD). 
