### PR TITLE
chore: lint sdcard.cpp and sdcard.h

### DIFF
--- a/examples/AllFunction/sdcard.cpp
+++ b/examples/AllFunction/sdcard.cpp
@@ -10,57 +10,43 @@
 #include "SD_MMC.h"
 #include "utilities.h"
 
-
-
 bool setupSdcard()
 {
     SD_MMC.setPins(SDMMC_CLK, SDMMC_CMD, SDMMC_DATA);
 
-    if (!SD_MMC.begin("/sdcard", true)) {
-        Serial.println("ERROR :SD Card Mount failed!");
+    if (!SD_MMC.begin("/sdcard", true))
+    {
+        Serial.println("ERROR: SD Card Mount failed!");
         return false;
     }
     uint8_t cardType = SD_MMC.cardType();
 
-    if (cardType == CARD_NONE) {
+    if (cardType == CARD_NONE)
+    {
         Serial.println("No SD_MMC card attached");
         return false;
     }
 
     Serial.print("SD_MMC Card Type: ");
-    if (cardType == CARD_MMC) {
+    if (cardType == CARD_MMC)
+    {
         Serial.println("MMC");
-    } else if (cardType == CARD_SD) {
+    }
+    else if (cardType == CARD_SD)
+    {
         Serial.println("SDSC");
-    } else if (cardType == CARD_SDHC) {
+    }
+    else if (cardType == CARD_SDHC)
+    {
         Serial.println("SDHC");
-    } else {
+    }
+    else
+    {
         Serial.println("UNKNOWN");
     }
 
     uint64_t cardSize = SD_MMC.cardSize() / (1024 * 1024);
     Serial.printf("SD_MMC Card Size: %lluMB\n", cardSize);
 
-
-
     return true;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/examples/AllFunction/sdcard.h
+++ b/examples/AllFunction/sdcard.h
@@ -9,12 +9,3 @@
 #pragma once
 
 bool setupSdcard();
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

Apply linting to the sdcard example files to standardize formatting

Chores:
- Standardize brace style and indentation in sdcard.cpp
- Remove extraneous blank lines and trailing whitespace in sdcard.cpp and sdcard.h