### PR TITLE
fix: update deep sleep mode reference page

### DIFF
--- a/examples/BIGIOT_Gnss_Upload/BIGIOT_Gnss_Upload.ino
+++ b/examples/BIGIOT_Gnss_Upload/BIGIOT_Gnss_Upload.ino
@@ -147,7 +147,7 @@ void deepsleep()
     By default, ESP32 will automatically power down the peripherals
     not needed by the wakeup source, but if you want to be a poweruser
     this is for you. Read in detail at the API docs
-    http://esp-idf.readthedocs.io/en/latest/api-reference/system/deep_sleep.html
+    https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/system/sleep_modes.html
     Left the line commented as an example of how to configure peripherals.
     The line below turns off all RTC peripherals in deep sleep.
     */

--- a/examples/MinimalDeepSleepExample/MinimalDeepSleepExample.ino
+++ b/examples/MinimalDeepSleepExample/MinimalDeepSleepExample.ino
@@ -150,7 +150,7 @@ void setup()
     By default, ESP32 will automatically power down the peripherals
     not needed by the wakeup source, but if you want to be a poweruser
     this is for you. Read in detail at the API docs
-    http://esp-idf.readthedocs.io/en/latest/api-reference/system/deep_sleep.html
+    https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/system/sleep_modes.html
     Left the line commented as an example of how to configure peripherals.
     The line below turns off all RTC peripherals in deep sleep.
     */

--- a/examples/MinimalModemAndEspSleep/MinimalModemAndEspSleep.ino
+++ b/examples/MinimalModemAndEspSleep/MinimalModemAndEspSleep.ino
@@ -231,7 +231,7 @@ void setup()
     By default, ESP32 will automatically power down the peripherals
     not needed by the wakeup source, but if you want to be a poweruser
     this is for you. Read in detail at the API docs
-    http://esp-idf.readthedocs.io/en/latest/api-reference/system/deep_sleep.html
+    https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/system/sleep_modes.html
     Left the line commented as an example of how to configure peripherals.
     The line below turns off all RTC peripherals in deep sleep.
     */


### PR DESCRIPTION
## Summary

Documentation:
- Replace outdated deep sleep API links with the current sleep_modes URL in BIGIOT_Gnss_Upload, MinimalDeepSleepExample, and MinimalModemAndEspSleep examples