### PR TITLE
fix: incorrect GPRS status

### DIFF
--- a/examples/MinimalModemSleepMode/MinimalModemSleepMode.ino
+++ b/examples/MinimalModemSleepMode/MinimalModemSleepMode.ino
@@ -186,8 +186,7 @@ void setup()
     // Activate network bearer, APN can not be configured by default,
     // if the SIM card is locked, please configure the correct APN and user password, use the gprsConnect() method
 
-    bool res = modem.isGprsConnected();
-    if (!res) {
+    if (!modem.isGprsConnected()) {
         modem.sendAT("+CNACT=0,1");
         if (modem.waitResponse() != 1) {
             Serial.println("Activate network bearer Failed!");
@@ -198,7 +197,7 @@ void setup()
         // }
     }
 
-
+    bool res = modem.isGprsConnected();
     Serial.print("GPRS status:");
     Serial.println(res ? "connected" : "not connected");
 

--- a/examples/ModemMqttPublishExample/ModemMqttPublishExample.ino
+++ b/examples/ModemMqttPublishExample/ModemMqttPublishExample.ino
@@ -203,8 +203,7 @@ void setup()
     // Activate network bearer, APN can not be configured by default,
     // if the SIM card is locked, please configure the correct APN and user password, use the gprsConnect() method
 
-    bool res = modem.isGprsConnected();
-    if (!res) {
+    if (!modem.isGprsConnected()) {
         modem.sendAT("+CNACT=0,1");
         if (modem.waitResponse() != 1) {
             Serial.println("Activate network bearer Failed!");
@@ -215,6 +214,7 @@ void setup()
         // }
     }
 
+    bool res = modem.isGprsConnected();
     Serial.print("GPRS status:");
     Serial.println(res ? "connected" : "not connected");
 

--- a/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
+++ b/examples/ModemMqttSubscribeExample/ModemMqttSubscribeExample.ino
@@ -230,8 +230,7 @@ void setup()
     Serial.println(register_info[s]);
 
 
-    bool res = modem.isGprsConnected();
-    if (!res) {
+    if (!modem.isGprsConnected()) {
         // Activate network bearer, APN can not be configured by default,
         // if the SIM card is locked, please configure the correct APN and user password, use the gprsConnect() method
         modem.sendAT("+CNACT=0,1");
@@ -244,6 +243,7 @@ void setup()
         // }
     }
 
+    bool res = modem.isGprsConnected();
     Serial.print("GPRS status:");
     Serial.println(res ? "connected" : "not connected");
 

--- a/examples/ModemMqttsExample/ModemMqttsExample.ino
+++ b/examples/ModemMqttsExample/ModemMqttsExample.ino
@@ -306,8 +306,7 @@ void setup()
     // if the SIM card is locked, please configure the correct APN and user
     // password, use the gprsConnect() method
 
-    bool res = modem.isGprsConnected();
-    if (!res) {
+    if (!modem.isGprsConnected()) {
         modem.sendAT("+CNACT=0,1");
         if (modem.waitResponse() != 1) {
             Serial.println("Activate network bearer Failed!");
@@ -318,6 +317,7 @@ void setup()
         // }
     }
 
+    bool res = modem.isGprsConnected();
     Serial.print("GPRS status:");
     Serial.println(res ? "connected" : "not connected");
 


### PR DESCRIPTION
## Summary

Bug Fixes:
- Re-check GPRS connection status after activation before printing in multiple example sketches.

## Why?

Let's see the below code.

https://github.com/Xinyuan-LilyGO/LilyGo-T-SIM7080G/blob/9d822b9e6ffe70137a4ba7a81fd566c1cc1bbe9d/examples/MinimalModemSleepMode/MinimalModemSleepMode.ino#L189-L203

First, `res` value is `false` if `modem.isGprsConnected();` is `false`.
Second, `res` value will be `true` after `modem.sendAT("+CNACT=0,1");` commands.
However serial will print `not connected` because `res` variable doesn't updated and still have old `false` value.

So we should re-check `modem.isGprsConnected();` value after `modem.sendAT("+CNACT=0,1");` commands.